### PR TITLE
Implement: assert_sequence for testing sequences

### DIFF
--- a/src/a000079/mod.rs
+++ b/src/a000079/mod.rs
@@ -11,19 +11,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::asserts::assert_sequence;
 
     #[test]
     fn test_a000079() {
-        assert_eq!(a000079(0), 1);
-        assert_eq!(a000079(1), 2);
-        assert_eq!(a000079(2), 4);
-        assert_eq!(a000079(3), 8);
-        assert_eq!(a000079(4), 16);
-        assert_eq!(a000079(5), 32);
-        assert_eq!(a000079(6), 64);
-        assert_eq!(a000079(7), 128);
-        assert_eq!(a000079(8), 256);
-        assert_eq!(a000079(9), 512);
-        assert_eq!(a000079(10), 1024);
+        let expected = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
+        assert_sequence(a000079, &expected);
     }
 }

--- a/src/a000217/mod.rs
+++ b/src/a000217/mod.rs
@@ -14,19 +14,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::asserts::assert_sequence;
 
     #[test]
     fn test_a000217() {
-        assert_eq!(a000217(0), 0);
-        assert_eq!(a000217(1), 1);
-        assert_eq!(a000217(2), 3);
-        assert_eq!(a000217(3), 6);
-        assert_eq!(a000217(4), 10);
-        assert_eq!(a000217(5), 15);
-        assert_eq!(a000217(6), 21);
-        assert_eq!(a000217(7), 28);
-        assert_eq!(a000217(8), 36);
-        assert_eq!(a000217(9), 45);
-        assert_eq!(a000217(10), 55);
+        let expected = [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55];
+        assert_sequence(a000217, &expected);
     }
 }

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,0 +1,9 @@
+#[cfg(test)]
+pub fn assert_sequence<T>(fn_seq: fn(T) -> T, expected: &[T])
+where
+    T: std::cmp::PartialEq + std::fmt::Debug + Sized + Copy + From<u8>,
+{
+    for (n, &expected) in expected.iter().enumerate() {
+        assert_eq!(fn_seq(T::from(n as u8)), expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod a000079;
 pub mod a000217;
+mod asserts;


### PR DESCRIPTION
`assert_sequence` is a function that takes a function and a sequences.
It compares the output of the function with the sequence.
For example, the following test checks the first 10 elements of the sequence A000217:

```rust
fn test_a000217() {
    let expected = [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55];
    assert_sequence(a000217, &expected);
}
```
