### PR TITLE
Migrate coverage reporting to octocov

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -1,0 +1,49 @@
+name: octocov
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  octocov:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 1
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: git-restore-mtime
+        uses: chetan/git-restore-mtime-action@v2.3
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: coverage
+        run: |
+          cargo install cargo-llvm-cov || true
+          cargo llvm-cov --lcov --output-path coverage.lcov
+
+      - name: Report coverage with octocov
+        uses: k1LoW/octocov-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config: .octocov.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,13 +70,3 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - run: cargo llvm-cov --lcov --output-path coverage.lcov
-
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.lcov
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
-          verbose: true

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,20 @@
+# https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
+coverage:
+  paths:
+    - coverage.lcov
+codeToTestRatio:
+  code:
+    - "**/*.rs"
+  test:
+    - "**/*_test.rs"
+testExecutionTime:
+  if: true
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+comment:
+  if: is_pull_request
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # rust-oeis-playground
 
+![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/rust-oeis-playground/coverage.svg)
+
 This is a playground for implementing sequences from the [OEIS](https://oeis.org/) in Rust.
 
 ## Directory structure


### PR DESCRIPTION
Add octocov configuration and workflow, update README coverage badge, and remove Codecov upload step.