### PR TITLE
Pin happy workflow reusable ref

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc


### PR DESCRIPTION
## Summary
- Pin the write-capable happy-commit reusable workflow call to a fixed `kitsuyui/gh-actions-workflows` commit.

## Verification
- `git diff --check`
- `actionlint .github/workflows/happy.yml`
- Resolved `kitsuyui/gh-actions-workflows@3717c78af3a5e594b7a81b063276e15fac7e08fc` via the GitHub API