### PR TITLE
Pin GitHub Actions refs to commit SHA

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -25,7 +25,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: git-restore-mtime
-        uses: chetan/git-restore-mtime-action@v2.3
+        uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3
 
       - uses: actions/cache@v5
         with:
@@ -43,7 +43,7 @@ jobs:
           cargo llvm-cov --lcov --output-path coverage.lcov
 
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main


### PR DESCRIPTION
## Summary

- Pin three external workflow references (currently using a tag or branch name) to immutable 40-char commit SHAs so the supply-chain input cannot be moved upstream silently.
- The trailing comment keeps the human-readable version visible for future Dependabot/Renovate updates.

## Changes

| file | before | after |
| --- | --- | --- |
| `.github/workflows/octocov.yml:28` | `chetan/git-restore-mtime-action@v2.3` | `chetan/git-restore-mtime-action@d186aca5...` (v2.3) |
| `.github/workflows/octocov.yml:46` | `k1LoW/octocov-action@v1` | `k1LoW/octocov-action@b3b6ee60...` (v1) |
| `.github/workflows/spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | same path `@9108d679...` (main) |

## Test plan

- [ ] CI (`octocov`, `spellcheck`, `test`) passes on this PR.