### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- Add top-level concurrency groups to the happy, octocov, and test workflows.
- Cancel superseded runs for the same workflow/ref so only the latest branch update continues.

## Validation
- `actionlint`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo build`

## Trade-offs
- `cancel-in-progress: true` cancels older runs for the same workflow/ref, so interrupted commits may need the latest run to finish before review.
