### PR TITLE
Remove unused cdylib surface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,3 @@
 name = "rust-oeis-playground"
 version = "0.1.0"
 edition = "2021"
-[lib]
-crate-type = ["cdylib"]
-[dependencies]
-num-traits = "0.2.19"


### PR DESCRIPTION
# Summary

- Remove the unused `cdylib` library surface from `Cargo.toml`.
- Drop the unused `num-traits` dependency.

# Checks

- cargo check
- cargo test (2 tests)
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo build
- cargo llvm-cov --lcov --output-path coverage.lcov
- git diff --check
- cargo metadata: dependencies=[], target kind/lib
