### PR TITLE
Avoid intermediate overflow in A000217

### DIFF
--- a/src/a000217/mod.rs
+++ b/src/a000217/mod.rs
@@ -5,10 +5,19 @@ where
     T: std::ops::Add<Output = T>
         + std::ops::Mul<Output = T>
         + std::ops::Div<Output = T>
+        + std::ops::Rem<Output = T>
+        + std::cmp::PartialEq
         + From<u8>
         + Copy,
 {
-    n * (n + T::from(1)) / T::from(2)
+    let one = T::from(1);
+    let two = T::from(2);
+
+    if n % two == T::from(0) {
+        (n / two) * (n + one)
+    } else {
+        n * ((n + one) / two)
+    }
 }
 
 #[cfg(test)]
@@ -20,5 +29,11 @@ mod tests {
     fn test_a000217() {
         let expected = [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55];
         assert_sequence(a000217, &expected);
+    }
+
+    #[test]
+    fn test_a000217_u8_boundary_without_intermediate_overflow() {
+        assert_eq!(a000217(16_u8), 136);
+        assert_eq!(a000217(22_u8), 253);
     }
 }


### PR DESCRIPTION
## Summary
This changes the triangular-number calculation so it divides the even factor before multiplication, which avoids intermediate overflow for small integer types.

## Tests
- `cargo check`
- `cargo test` (3 tests)
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test --release` (3 tests)
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `cargo test -- --nocapture test_a000217_u8_boundary_without_intermediate_overflow`
- `git diff --check`

## Notes
- Added u8 boundary tests for values whose final triangular number fits.
- No generated artifacts were committed.
