### PR TITLE
Gate asserts module to test builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod a000079;
 pub mod a000217;
+#[cfg(test)]
 mod asserts;


### PR DESCRIPTION
## Summary

Mark the internal `asserts` helper module as test-only at the module declaration site.

## Changes

- Add `#[cfg(test)]` to `mod asserts;` in `src/lib.rs`.
- Keep the existing sequence modules and test helper function unchanged.

## Validation

- `cargo fmt --all`
- `cargo check`
- `cargo test` (3 tests)
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `actionlint`
- `cargo doc --no-deps` (completed with existing bare URL warnings)
- `git diff --check`
