### PR TITLE
Return Option<T> from a000079 and a000217 to propagate overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 name = "rust-oeis-playground"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+num-traits = "0.2.19"

--- a/src/a000079/mod.rs
+++ b/src/a000079/mod.rs
@@ -1,11 +1,12 @@
 // Contents: Power of 2
 /// https://oeis.org/A000079
 /// Power of 2
-pub fn a000079<T>(n: T) -> T
+pub fn a000079<T>(n: T) -> Option<T>
 where
-    T: std::ops::Shl<Output = T> + From<u8>,
+    T: num_traits::CheckedShl + num_traits::One + num_traits::ToPrimitive,
 {
-    T::from(1) << n
+    let shift = n.to_u32()?;
+    T::one().checked_shl(shift)
 }
 
 #[cfg(test)]
@@ -17,5 +18,11 @@ mod tests {
     fn test_a000079() {
         let expected = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
         assert_sequence(a000079, &expected);
+    }
+
+    #[test]
+    fn test_a000079_overflow() {
+        assert_eq!(a000079::<u8>(8_u8), None);
+        assert_eq!(a000079::<u32>(32_u32), None);
     }
 }

--- a/src/a000217/mod.rs
+++ b/src/a000217/mod.rs
@@ -1,9 +1,9 @@
 /// https://oeis.org/A000217
 /// Triangular numbers: a(n) = binomial(n+1, 2) = n*(n+1)/2.
-pub fn a000217<T>(n: T) -> T
+pub fn a000217<T>(n: T) -> Option<T>
 where
-    T: std::ops::Add<Output = T>
-        + std::ops::Mul<Output = T>
+    T: num_traits::CheckedAdd
+        + num_traits::CheckedMul
         + std::ops::Div<Output = T>
         + std::ops::Rem<Output = T>
         + std::cmp::PartialEq
@@ -12,11 +12,11 @@ where
 {
     let one = T::from(1);
     let two = T::from(2);
-
+    let n_plus_one = n.checked_add(&one)?;
     if n % two == T::from(0) {
-        (n / two) * (n + one)
+        (n / two).checked_mul(&n_plus_one)
     } else {
-        n * ((n + one) / two)
+        n.checked_mul(&(n_plus_one / two))
     }
 }
 
@@ -32,8 +32,9 @@ mod tests {
     }
 
     #[test]
-    fn test_a000217_u8_boundary_without_intermediate_overflow() {
-        assert_eq!(a000217(16_u8), 136);
-        assert_eq!(a000217(22_u8), 253);
+    fn test_a000217_u8_boundary() {
+        assert_eq!(a000217(16_u8), Some(136));
+        assert_eq!(a000217(22_u8), Some(253));
+        assert_eq!(a000217(23_u8), None);
     }
 }

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,9 +1,12 @@
 #[cfg(test)]
-pub fn assert_sequence<T>(fn_seq: fn(T) -> T, expected: &[T])
+pub fn assert_sequence<T, F>(fn_seq: F, expected: &[T])
 where
     T: std::cmp::PartialEq + std::fmt::Debug + Sized + Copy + From<u8>,
+    F: Fn(T) -> Option<T>,
 {
     for (n, &expected) in expected.iter().enumerate() {
-        assert_eq!(fn_seq(T::from(n as u8)), expected);
+        let result =
+            fn_seq(T::from(n as u8)).expect("sequence value should not overflow for small n");
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
## Summary

`a000079` and `a000217` previously had no error path for out-of-range inputs:
- Debug builds panicked with a non-descriptive message
- Release builds silently returned wrong values (wrapping arithmetic)

Callers had no way to detect whether a result was valid.

## Changes

- **`a000079`**: Change return type from `T` to `Option<T>`. Use `num_traits::CheckedShl` + `ToPrimitive` to detect shift overflow. Returns `None` when `n >= T::BITS`.
- **`a000217`**: Change return type from `T` to `Option<T>`. Use `num_traits::CheckedAdd` + `CheckedMul` to detect overflow in both the addition and multiplication steps. Returns `None` on overflow.
- **`asserts`**: Update `assert_sequence` helper to accept `Fn(T) -> Option<T>` and unwrap with a clear error message.
- **`Cargo.toml`**: Add `num-traits = "0.2"` dependency for checked arithmetic traits.
- Add overflow tests for both functions.

## Verification

- `cargo clippy -- -D warnings`: clean
- `cargo test`: 4 tests passed (including new overflow tests)
- `cargo fmt --all`: clean
- `cargo check`: clean

## Note on open PRs

PR #26 (`fix/audit-a000079-signed-shift-001`) adds an `Unsigned` bound to `a000079` to prevent use with signed types. This PR changes `a000079`'s return type and trait bounds independently. The two PRs touch the same function — one of them will need a rebase after the other merges.
