### PR TITLE
Restrict a000217 to integer types via PrimInt bound

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 name = "rust-oeis-playground"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+num-traits = "0.2.19"

--- a/src/a000079/mod.rs
+++ b/src/a000079/mod.rs
@@ -1,11 +1,12 @@
 // Contents: Power of 2
 /// https://oeis.org/A000079
 /// Power of 2
-pub fn a000079<T>(n: T) -> T
+pub fn a000079<T>(n: T) -> Option<T>
 where
-    T: std::ops::Shl<Output = T> + From<u8>,
+    T: num_traits::CheckedShl + num_traits::One + num_traits::ToPrimitive,
 {
-    T::from(1) << n
+    let shift = n.to_u32()?;
+    T::one().checked_shl(shift)
 }
 
 #[cfg(test)]
@@ -17,5 +18,11 @@ mod tests {
     fn test_a000079() {
         let expected = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
         assert_sequence(a000079, &expected);
+    }
+
+    #[test]
+    fn test_a000079_overflow() {
+        assert_eq!(a000079::<u8>(8_u8), None);
+        assert_eq!(a000079::<u32>(32_u32), None);
     }
 }

--- a/src/a000217/mod.rs
+++ b/src/a000217/mod.rs
@@ -1,9 +1,9 @@
 /// https://oeis.org/A000217
 /// Triangular numbers: a(n) = binomial(n+1, 2) = n*(n+1)/2.
-pub fn a000217<T>(n: T) -> T
+pub fn a000217<T>(n: T) -> Option<T>
 where
-    T: std::ops::Add<Output = T>
-        + std::ops::Mul<Output = T>
+    T: num_traits::CheckedAdd
+        + num_traits::CheckedMul
         + std::ops::Div<Output = T>
         + std::ops::Rem<Output = T>
         + std::cmp::PartialEq
@@ -12,11 +12,11 @@ where
 {
     let one = T::from(1);
     let two = T::from(2);
-
+    let n_plus_one = n.checked_add(&one)?;
     if n % two == T::from(0) {
-        (n / two) * (n + one)
+        (n / two).checked_mul(&n_plus_one)
     } else {
-        n * ((n + one) / two)
+        n.checked_mul(&(n_plus_one / two))
     }
 }
 
@@ -32,8 +32,9 @@ mod tests {
     }
 
     #[test]
-    fn test_a000217_u8_boundary_without_intermediate_overflow() {
-        assert_eq!(a000217(16_u8), 136);
-        assert_eq!(a000217(22_u8), 253);
+    fn test_a000217_u8_boundary() {
+        assert_eq!(a000217(16_u8), Some(136));
+        assert_eq!(a000217(22_u8), Some(253));
+        assert_eq!(a000217(23_u8), None);
     }
 }

--- a/src/a000217/mod.rs
+++ b/src/a000217/mod.rs
@@ -1,19 +1,14 @@
 /// https://oeis.org/A000217
 /// Triangular numbers: a(n) = binomial(n+1, 2) = n*(n+1)/2.
+/// T must be an integer type; OEIS A000217 is defined only for non-negative integer indices.
 pub fn a000217<T>(n: T) -> Option<T>
 where
-    T: num_traits::CheckedAdd
-        + num_traits::CheckedMul
-        + std::ops::Div<Output = T>
-        + std::ops::Rem<Output = T>
-        + std::cmp::PartialEq
-        + From<u8>
-        + Copy,
+    T: num_traits::PrimInt,
 {
-    let one = T::from(1);
-    let two = T::from(2);
+    let one = T::one();
+    let two = one + one;
     let n_plus_one = n.checked_add(&one)?;
-    if n % two == T::from(0) {
+    if n % two == T::zero() {
         (n / two).checked_mul(&n_plus_one)
     } else {
         n.checked_mul(&(n_plus_one / two))

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,9 +1,12 @@
 #[cfg(test)]
-pub fn assert_sequence<T>(fn_seq: fn(T) -> T, expected: &[T])
+pub fn assert_sequence<T, F>(fn_seq: F, expected: &[T])
 where
     T: std::cmp::PartialEq + std::fmt::Debug + Sized + Copy + From<u8>,
+    F: Fn(T) -> Option<T>,
 {
     for (n, &expected) in expected.iter().enumerate() {
-        assert_eq!(fn_seq(T::from(n as u8)), expected);
+        let result =
+            fn_seq(T::from(n as u8)).expect("sequence value should not overflow for small n");
+        assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
## Summary

OEIS A000217 (triangular numbers) is defined only for non-negative integer indices, but the previous trait bounds (`CheckedAdd + CheckedMul + Div + Rem + PartialEq + From<u8> + Copy`) did not make this restriction self-documenting.

This PR replaces those six bounds with the single `PrimInt` trait, which:
- Explicitly names the integer-type requirement
- Rejects floating-point types (`f32`, `f64`) at compile time
- Implies all previously listed arithmetic operations (`CheckedAdd`, `CheckedMul`, `Div`, `Rem`, `PartialEq`, `Copy`)

The function body is updated to use `T::one()` and `T::zero()` in place of `T::from(1)` and `T::from(0)` to avoid ambiguity with `NumCast::from` (which `PrimInt` also implies).

A doc comment is added to state the integer-type requirement explicitly.

## Changes

- `src/a000217/mod.rs`: Replace trait bound with `PrimInt`, update literals to `one()`/`zero()`, add doc note

## Verification

- `cargo fmt --all` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 4/4 passing (including overflow boundary tests)

## Trade-offs

`PrimInt` is more restrictive than the previous bounds (it requires bit-shift operations etc.), which could break a hypothetical custom integer newtype that implemented each of the six previous traits individually but not `PrimInt`. In practice, all standard Rust integer types satisfy `PrimInt`, so real callers are unaffected.
