### PR TITLE
docs: document None return conditions for a000079, a000217, and assert_sequence

### DIFF
--- a/src/a000079/mod.rs
+++ b/src/a000079/mod.rs
@@ -1,6 +1,10 @@
 // Contents: Power of 2
-/// https://oeis.org/A000079
-/// Power of 2
+/// <https://oeis.org/A000079>
+///
+/// Returns the n-th power of 2 (i.e. `2^n`).
+///
+/// Returns `None` if `n` cannot be converted to `u32` (e.g. the value is
+/// negative or exceeds [`u32::MAX`]), or if `2^n` would overflow `T`.
 pub fn a000079<T>(n: T) -> Option<T>
 where
     T: num_traits::CheckedShl + num_traits::One + num_traits::ToPrimitive,

--- a/src/a000217/mod.rs
+++ b/src/a000217/mod.rs
@@ -1,6 +1,11 @@
-/// https://oeis.org/A000217
-/// Triangular numbers: a(n) = binomial(n+1, 2) = n*(n+1)/2.
-/// T must be an integer type; OEIS A000217 is defined only for non-negative integer indices.
+/// <https://oeis.org/A000217>
+///
+/// Triangular numbers: `a(n) = n * (n + 1) / 2`.
+///
+/// `T` must be a primitive integer type. OEIS A000217 is defined only for
+/// non-negative integer indices.
+///
+/// Returns `None` if `n + 1` or the subsequent multiplication overflows `T`.
 pub fn a000217<T>(n: T) -> Option<T>
 where
     T: num_traits::PrimInt,

--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,4 +1,10 @@
 #[cfg(test)]
+/// Asserts that `fn_seq(T::from(n as u8))` equals `expected[n]` for each index `n`.
+///
+/// # Panics
+///
+/// Panics if any sequence value does not match or if `fn_seq` returns `None`
+/// for an index within the provided slice (i.e. unexpected overflow for small `n`).
 pub fn assert_sequence<T, F>(fn_seq: F, expected: &[T])
 where
     T: std::cmp::PartialEq + std::fmt::Debug + Sized + Copy + From<u8>,


### PR DESCRIPTION
## Summary

Add `None`-return documentation to `a000079`, `a000217`, and `assert_sequence`.

Previous doc comments described the OEIS sequence but did not say when the
function returns `None`. After the overflow-safe refactoring (using
`checked_shl`, `checked_add`, `checked_mul`), the functions no longer panic;
they return `None` on overflow. Document that contract explicitly.

### Changes per file

- `src/a000079/mod.rs`: Clarify that `None` is returned when `n` cannot be
  converted to `u32` (negative or exceeds `u32::MAX`) or when `2^n` would
  overflow `T`. Use angle-bracket URL syntax for docs.rs link rendering.
- `src/a000217/mod.rs`: Clarify that `None` is returned on `n + 1` overflow
  or multiplication overflow. Update URL syntax.
- `src/asserts.rs`: Add a doc comment documenting the two panic conditions
  (`None` return or assertion failure).

## Verification

`cargo test` passes (4 tests). `cargo fmt --check`, `cargo clippy`, and
`cargo doc` (0 warnings) all clean.
