### PR TITLE
Remove codeToTestRatio from octocov config

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,11 +2,6 @@
 coverage:
   paths:
     - coverage.lcov
-codeToTestRatio:
-  code:
-    - "**/*.rs"
-  test:
-    - "**/*_test.rs"
 testExecutionTime:
   if: true
 diff:


### PR DESCRIPTION
The `codeToTestRatio.test` glob `**/*_test.rs` matches no files in this
project. Rust unit tests are written as `#[cfg(test)]` inline modules
inside source files (e.g. `src/a000079/mod.rs`, `src/a000217/mod.rs`),
not in separate `*_test.rs` files (which is a Go naming convention).

The mismatch caused octocov to always report 0 test lines, making the
code-to-test ratio metric incorrect despite tests being present.

File-level glob matching cannot distinguish test lines from production
lines within the same `.rs` file, so the section is removed rather than
replaced with a similarly imprecise glob.
