### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ This is a playground for implementing sequences from the [OEIS](https://oeis.org
 
 - `src/{sequence_name}/mod.rs` - Contains the implementation of the sequence.
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`
+- **pre-push**: the above plus `cargo test`
+
+CI still runs the full suite (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 ## License
 
 The OEIS sequences are licensed under the [OEIS End-User License Agreement](https://oeis.org/wiki/The_OEIS_End-User_License_Agreement). The implementations in this repository are licensed under the MIT license.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+
+pre-push:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy -- -D warnings
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` to mirror the same fmt, clippy, and test checks that CI runs, so failures surface locally before reaching GitHub Actions.
- Documents the setup in `README.md` under a new `## Development` section.
- CI workflows are left completely unchanged.

## Changes

- **`lefthook.yml`** (new): pre-commit runs `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`; pre-push adds `cargo test`.
- **`README.md`**: new `## Development` section (inserted before `## License`) explaining how to install and what the hooks do.

## Verification

All mirrored commands were verified to pass on current code before committing:

- `cargo fmt --all -- --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo test` — 4 tests passed

The pre-commit hook fired on commit and the pre-push hook fired on push — both passed.

## Notes

- Requires [`lefthook`](https://lefthook.dev/) on your PATH and a working `cargo` installation.
- Run `lefthook install` once after cloning to activate the hooks.
