### PR TITLE
chore: set publish = false to prevent accidental crates.io publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-oeis-playground"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 num-traits = "0.2.19"


### PR DESCRIPTION
## Summary

This playground repo is not intended for crates.io distribution.
The README states: "This is a playground for implementing sequences from the OEIS."

The crate is not currently published on crates.io, but `cargo publish` can
be run by anyone with the right credentials. Setting `publish = false` in
`Cargo.toml` makes it fail immediately:

```
error: attempting to upload to crates.io when publish is set to false
```

This prevents accidental publication via a mistyped `cargo publish` command
or leaked CI credentials.

## Change

One line added to `Cargo.toml`:

```toml
publish = false
```

## Trade-offs

- Removes the ability to publish to crates.io intentionally. If the intent
  ever changes, remove the `publish = false` line and add an explicit
  publish workflow.
