### PR TITLE
Add cargo audit security scan workflow

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,29 @@
+name: Security Audit
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 3 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit


### PR DESCRIPTION
## Summary

Add a dedicated `cargo-audit.yml` workflow that runs `cargo audit` to check Rust dependencies against the RustSec Advisory Database.

## Changes

- New `.github/workflows/cargo-audit.yml` with:
  - Triggers: `push` (main), `pull_request`, `schedule` (weekly Monday 03:00 UTC)
  - SHA-pinned action refs for supply-chain integrity
  - Installs `cargo-audit` via `taiki-e/install-action` and runs `cargo audit`

## Problem addressed

The CI pipeline had no automated check for known CVEs in Rust dependencies. While Renovate handles dependency updates, a newly published CVE can leave a vulnerable version in `Cargo.lock` until the next Renovate run. Adding `cargo audit` reduces that detection window.

## Validation

- YAML syntax: valid
- actionlint: 0 findings
- collateral check: clean
- Scope: workflow file only, no Rust source changes

## Notes

Action refs in this new workflow are SHA-pinned (unlike existing `test.yml`). The existing `test.yml` mutable refs are a separate concern and out of scope for this PR.