### PR TITLE
Replace From<u8> with TryFrom<usize> in assert_sequence to eliminate silent index truncation

### DIFF
--- a/src/asserts.rs
+++ b/src/asserts.rs
@@ -1,18 +1,20 @@
 #[cfg(test)]
-/// Asserts that `fn_seq(T::from(n as u8))` equals `expected[n]` for each index `n`.
+/// Asserts that `fn_seq(T::try_from(n).unwrap())` equals `expected[n]` for each index `n`.
 ///
 /// # Panics
 ///
-/// Panics if any sequence value does not match or if `fn_seq` returns `None`
-/// for an index within the provided slice (i.e. unexpected overflow for small `n`).
+/// Panics if any sequence value does not match, if `fn_seq` returns `None`
+/// for an index within the provided slice, or if the index `n` cannot be
+/// represented as `T`.
 pub fn assert_sequence<T, F>(fn_seq: F, expected: &[T])
 where
-    T: std::cmp::PartialEq + std::fmt::Debug + Sized + Copy + From<u8>,
+    T: std::cmp::PartialEq + std::fmt::Debug + Sized + Copy + TryFrom<usize>,
+    T::Error: std::fmt::Debug,
     F: Fn(T) -> Option<T>,
 {
     for (n, &expected) in expected.iter().enumerate() {
-        let result =
-            fn_seq(T::from(n as u8)).expect("sequence value should not overflow for small n");
+        let index = T::try_from(n).expect("sequence index exceeds type range");
+        let result = fn_seq(index).expect("sequence value should not overflow for small n");
         assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
## Summary

`assert_sequence` in `src/asserts.rs` was silently truncating the loop index when calling `T::from(n as u8)` — any slice longer than 255 elements would wrap the index to `0..=255` without panicking, causing the test helper to evaluate the sequence function at the wrong indices.

This PR replaces the `From<u8>` bound with `TryFrom<usize>` and uses `T::try_from(n)` in the loop body. The conversion now panics with a clear message if the index ever exceeds the type's range, making the hidden constraint explicit.

## Changes

- `src/asserts.rs`: `From<u8>` → `TryFrom<usize>` on `assert_sequence`; loop body uses `try_from` instead of `n as u8` cast
- Docstring updated to document the new `Panics` condition

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy -- -D warnings`: clean  
- `cargo test`: all 4 tests pass
- Existing callers (`a000079`, `a000217`) compile unchanged — both `u32` and `i32` implement `TryFrom<usize>`
